### PR TITLE
fix: teaching axis

### DIFF
--- a/src/app/registrar-certificado/[requestID]/page.tsx
+++ b/src/app/registrar-certificado/[requestID]/page.tsx
@@ -151,6 +151,9 @@ export default function RegistePageTest({ params }: idProps) {
     setSelectedAtividade(
       selectedAxis?.id != null ? String(selectedAxis?.id) : '0'
     );
+
+    setSelectedEixo(certificateData[certificateIndex]?.eixoAtividade || '');
+
   }, [
     activitiesData,
     certificateData,
@@ -159,6 +162,7 @@ export default function RegistePageTest({ params }: idProps) {
     setDataInicial,
     setHoras,
     setSelectedAtividade,
+    setSelectedEixo,
     setTitulo
   ]);
 


### PR DESCRIPTION
Problema: O campo eixo de ensino não aparece nenhuma informação na edição de um rascunho de solicitação

Solução: Foi adicionado o set para receber o eixo de ensino.